### PR TITLE
Fix datetime assubstitute timezone

### DIFF
--- a/ClickHouse.Ado/ClickHouseParameter.cs
+++ b/ClickHouse.Ado/ClickHouseParameter.cs
@@ -46,9 +46,9 @@ namespace ClickHouse.Ado
 #endif
                 || (DbType==0 && val is DateTime)
             )
-                return $"'{(DateTime)val:yyyy-MM-dd HH:mm:ss}'";
+                return $"toDateTime('{((DateTime)val).ToUniversalTime():yyyy-MM-dd HH:mm:ss}', 'UTC')";
             if (DbType == DbType.Date)
-                return $"'{(DateTime)val:yyyy-MM-dd}'";
+                return $"toDate('{((DateTime)val).ToUniversalTime():yyyy-MM-dd}', 'UTC')";
             if ((DbType != 0
 #if !NETCOREAPP11
                  && DbType != DbType.Object

--- a/ClickHouse.Test/ClickHouse.Test.csproj
+++ b/ClickHouse.Test/ClickHouse.Test.csproj
@@ -57,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClickHouseConnectionSettingsTests\ToStringTests.cs" />
+    <Compile Include="ClickHouseParameterTest.cs" />
     <Compile Include="SimpleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/ClickHouse.Test/ClickHouseParameterTest.cs
+++ b/ClickHouse.Test/ClickHouseParameterTest.cs
@@ -1,0 +1,44 @@
+﻿using ClickHouse.Ado;
+using NUnit.Framework;
+using System;
+
+namespace ClickHouse.Test
+{
+    [TestFixture]
+    public class ClickHouseParameterTest
+    {
+        [Test]
+        public void AsSubstitudeDateTime()
+        {
+            //Arrange 
+            ClickHouseParameter parameter = new ClickHouseParameter()
+            {
+                DbType = System.Data.DbType.DateTime,
+                Value = new DateTime(2020, 1, 1, 10, 0, 0, DateTimeKind.Utc)
+            };
+
+            //Act
+            var res = parameter.AsSubstitute();
+
+            //Assert
+            Assert.AreEqual("toDateTime('2020-01-01 10:00:00', 'UTC')", res);
+        }
+
+        [Test]
+        public void AsSubstitudeDate()
+        {
+            //Arrange 
+            ClickHouseParameter parameter = new ClickHouseParameter()
+            {
+                DbType = System.Data.DbType.Date,
+                Value = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            };
+
+            //Act
+            var res = parameter.AsSubstitute();
+
+            //Assert
+            Assert.AreEqual("toDate('2020-01-01', 'UTC')", res);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #
Fix Timezone for AsSubstitute for DateTime Parameter
Changes:
- change AsSubstitute method of ClickHouseParameter for correct work with timezone
